### PR TITLE
Add autocompletion support for USBHub.device

### DIFF
--- a/capablerobot_usbhub/main.py
+++ b/capablerobot_usbhub/main.py
@@ -30,6 +30,7 @@ import copy
 import subprocess
 import weakref
 import sys
+from typing import Dict
 
 import usb.core
 import usb.util
@@ -83,7 +84,7 @@ class USBHub:
 
             self.backend = usb.backend.libusb1.get_backend(find_library=lambda x: dllpath)
 
-        self.devices = {}
+        self.devices: Dict[str, USBHubDevice] = {}
         self.attach(vendor, product)
 
         self.definition = {}


### PR DESCRIPTION
Add a small typing change to support auto-completion when calling into device.

Validated on 3.6.8 and 3.8.1 on Windows using vscode.